### PR TITLE
feat: elemental fantastic success status effects

### DIFF
--- a/css/marvel-multiverse.css
+++ b/css/marvel-multiverse.css
@@ -1519,3 +1519,7 @@
   display: flex;
   flex-direction: column;
 }
+
+.mm-custom-header .chat-control {
+  display: none !important;
+}

--- a/marvel-multiverse.mjs
+++ b/marvel-multiverse.mjs
@@ -92,6 +92,20 @@ Hooks.once("init", () => {
   CONFIG.Dice.rolls.push(dice.MarvelMultiverseRoll);
   CONFIG.Dice.terms.m = dice.MarvelDie;
 
+  // Register elemental status effects so toggleStatusEffect() resolves them
+  CONFIG.statusEffects = CONFIG.statusEffects.concat(
+    Object.entries(MARVEL_MULTIVERSE.elements)
+      .filter(([, el]) => el.statusId)
+      .map(([, el]) => ({
+        id: el.statusId,
+        name: el.statusId.charAt(0).toUpperCase() + el.statusId.slice(1),
+        img: `systems/marvel-multiverse/icons/statuses/${el.statusId}.svg`,
+      }))
+      .filter(
+        (entry, idx, arr) => arr.findIndex((e) => e.id === entry.id) === idx
+      )
+  );
+
   // Add fonts
   _configureFonts();
 

--- a/marvel-multiverse.mjs
+++ b/marvel-multiverse.mjs
@@ -217,6 +217,51 @@ function _configureFonts() {
 }
 
 /* -------------------------------------------- */
+/*  Render Chat Message Hook                    */
+/* -------------------------------------------- */
+
+Hooks.on("renderChatMessage", (message, html) => {
+  const flavorEl = html.find ? html.find(".mm-roll-flavor") : html.querySelector?.(".mm-roll-flavor");
+  const flavor = flavorEl?.[0] ?? flavorEl;
+  if (!flavor) return;
+
+  const tokenImg = flavor.dataset.tokenImg;
+  const header = html.find ? html.find(".message-header")[0] : html.querySelector(".message-header");
+  if (!header) return;
+
+  header.classList.add("mm-custom-header");
+  header.style.cssText = "background:#8b0502;padding:2px 8px;position:relative;overflow:visible;min-height:32px;align-items:center;flex-wrap:nowrap;display:flex;";
+
+  const sender = header.querySelector(".message-sender");
+  if (sender) {
+    sender.style.cssText = "color:#fff;font-weight:700;font-size:14px;white-space:nowrap;flex:1;padding-left:" + (tokenImg ? "39px" : "0") + ";";
+    const nameEl = sender.querySelector(".title");
+    if (nameEl) nameEl.style.color = "#fff";
+  }
+
+  const timestamp = header.querySelector(".message-timestamp");
+  if (timestamp) timestamp.style.cssText = "color:rgba(255,255,255,0.7);white-space:nowrap;font-size:10px;";
+
+  const metadata = header.querySelector(".message-metadata");
+  if (metadata) metadata.style.cssText = "white-space:nowrap;flex-shrink:0;margin-left:auto;";
+
+  const allControls = header.querySelectorAll(".chat-control, [data-context-menu]");
+  allControls.forEach(el => el.style.cssText = "display:none !important;");
+
+  const flavorInHeader = header.querySelector(".flavor-text");
+  if (flavorInHeader) {
+    header.parentNode.insertBefore(flavorInHeader, header.nextSibling);
+  }
+
+  if (tokenImg) {
+    const img = document.createElement("img");
+    img.src = tokenImg;
+    img.style.cssText = "position:absolute;left:4px;top:50%;transform:translateY(-50%);width:36px;height:36px;border:none;border-radius:50%;object-fit:cover;";
+    header.insertBefore(img, header.firstChild);
+  }
+});
+
+/* -------------------------------------------- */
 /*  Ready Hook                                  */
 /* -------------------------------------------- */
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -151,35 +151,72 @@ MARVEL_MULTIVERSE.elements = {
   air: {
     label: "Air",
     fantasticEffect: "Target is knocked prone for one round.",
+    statusId: "prone",
   },
   earth: {
     label: "Earth",
     fantasticEffect: "Target moves at half speed for one round.",
+    statusId: "exhaustion",
   },
   electricity: {
     label: "Electricity",
     fantasticEffect: "Stuns target for one round.",
+    statusId: "stunned",
   },
-  energy: { label: "Energy", fantasticEffect: "Blinds target for one round." },
-  fire: { label: "Fire", fantasticEffect: "Sets target ablaze." },
+  energy: {
+    label: "Energy",
+    fantasticEffect: "Blinds target for one round.",
+    statusId: "blinded",
+  },
+  fire: {
+    label: "Fire",
+    fantasticEffect: "Sets target ablaze.",
+    statusId: "bleeding",
+  },
   force: {
     label: "Force",
     fantasticEffect: "Target has trouble on all actions for one round.",
+    statusId: "encumbered",
   },
   hellfire: {
     label: "Hellfire",
     fantasticEffect: "Splits damage equally between Health and Focus.",
   },
-  ice: { label: "Ice", fantasticEffect: "Paralyzes target for one round." },
-  iron: { label: "Iron", fantasticEffect: "Pins target for one round." },
-  sound: { label: "Sound", fantasticEffect: "Deafens target for one round." },
+  ice: {
+    label: "Ice",
+    fantasticEffect: "Paralyzes target for one round.",
+    statusId: "paralyzed",
+  },
+  iron: {
+    label: "Iron",
+    fantasticEffect: "Pins target for one round.",
+    statusId: "restrained",
+  },
+  sound: {
+    label: "Sound",
+    fantasticEffect: "Deafens target for one round.",
+    statusId: "deafened",
+  },
   water: {
     label: "Water",
     fantasticEffect: "Surprises target until the end of the next round.",
+    statusId: "surprised",
   },
-  toxin: { label: "Toxin", fantasticEffect: "The target is poisoned." },
-  chemical: { label: "Chemical", fantasticEffect: "The target is corroding." },
-  swarm: { label: "Swarm", fantasticEffect: "The target is frightened." },
+  toxin: {
+    label: "Toxin",
+    fantasticEffect: "The target is poisoned.",
+    statusId: "poisoned",
+  },
+  chemical: {
+    label: "Chemical",
+    fantasticEffect: "The target is corroding.",
+    statusId: "bleeding",
+  },
+  swarm: {
+    label: "Swarm",
+    fantasticEffect: "The target is frightened.",
+    statusId: "frightened",
+  },
 };
 
 MARVEL_MULTIVERSE.teamManeuvers = [

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -260,12 +260,13 @@ export class ChatMessageMarvel extends ChatMessage {
    * @param {string} fantastic
    */
   async _handleDamageChatButton(messageId, flavorText, fantastic) {
-    const re = /ability:\s(?<ability>\w*)/;
-    const dmgTypeRe = /damagetype:\s(?<damageType>\w*)/;
-    const elementRe = /element:\s(?<element>\w*)/;
-    const ability = re.exec(flavorText).groups.ability;
+    const re = /(?:\[ability\]|ability:)\s*(?<ability>\w+)/i;
+    const dmgTypeRe = /(?:\[damageType\]|damage\s*type:)\s*(?<damageType>\w+)/i;
+    const elementRe = /(?:\[element\]|element:)\s*(?<element>\w+)/i;
+    const ability = re.exec(flavorText)?.groups?.ability;
+    if (!ability) return;
     const damageType = dmgTypeRe.exec(flavorText)?.groups?.damageType;
-    const element = elementRe.exec(flavorText)?.groups?.element;
+    const elementMatch = elementRe.exec(flavorText)?.groups?.element;
     const abilityAbr = MARVEL_MULTIVERSE.damageAbilityAbr[ability] ?? ability;
     const chatMessage = game.messages.get(messageId);
     const sixOneSixPool = chatMessage.rolls[0].terms[0];
@@ -321,8 +322,8 @@ export class ChatMessageMarvel extends ChatMessage {
         } &#42; damage multiplier: ${damageMultiplier} + ${ability} score ${abilityValue} of damage.</p>`
       );
     }
-    if (fantastic && element) {
-      const elementConfig = CONFIG.MARVEL_MULTIVERSE.elements[element];
+    if (fantastic && elementMatch) {
+      const elementConfig = CONFIG.MARVEL_MULTIVERSE.elements[elementMatch];
       if (elementConfig) {
         damageContent.push(
           `<p><b>Fantastic Elemental Effect (${elementConfig.label}):</b> ${elementConfig.fantasticEffect}</p>`

--- a/module/documents/chat-message.mjs
+++ b/module/documents/chat-message.mjs
@@ -262,8 +262,10 @@ export class ChatMessageMarvel extends ChatMessage {
   async _handleDamageChatButton(messageId, flavorText, fantastic) {
     const re = /ability:\s(?<ability>\w*)/;
     const dmgTypeRe = /damagetype:\s(?<damageType>\w*)/;
+    const elementRe = /element:\s(?<element>\w*)/;
     const ability = re.exec(flavorText).groups.ability;
     const damageType = dmgTypeRe.exec(flavorText)?.groups?.damageType;
+    const element = elementRe.exec(flavorText)?.groups?.element;
     const abilityAbr = MARVEL_MULTIVERSE.damageAbilityAbr[ability] ?? ability;
     const chatMessage = game.messages.get(messageId);
     const sixOneSixPool = chatMessage.rolls[0].terms[0];
@@ -319,7 +321,21 @@ export class ChatMessageMarvel extends ChatMessage {
         } &#42; damage multiplier: ${damageMultiplier} + ${ability} score ${abilityValue} of damage.</p>`
       );
     }
-    // const content = `<p>Delivers <b>${dmg}</b> points re: MarvelDie: ${marvelDie.total} &#42; damage multiplier: &#40; ${actor.system.abilities[abilityAbr].damageMultiplier} - damageReduction: ${damageReduction} &#61; ${damageMultiplier} &#41; + ${ability} score ${abilityValue} of damage.</p>`;
+    if (fantastic && element) {
+      const elementConfig = CONFIG.MARVEL_MULTIVERSE.elements[element];
+      if (elementConfig) {
+        damageContent.push(
+          `<p><b>Fantastic Elemental Effect (${elementConfig.label}):</b> ${elementConfig.fantasticEffect}</p>`
+        );
+        if (elementConfig.statusId) {
+          for (const target of targets) {
+            await target.toggleStatusEffect(elementConfig.statusId, {
+              active: true,
+            });
+          }
+        }
+      }
+    }
 
     const msgData = {
       speaker: ChatMessageMarvel.getSpeaker({ actor: actor }),

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,3 +1,5 @@
+import { buildRollFlavor } from "../helpers/roll-flavor.mjs";
+
 /**
  * Extend the basic Item with some very simple modifications.
  * @extends {Item}
@@ -47,28 +49,25 @@ export class MarvelMultiverseItem extends Item {
     // Initialize chat data.
     const speaker = ChatMessage.getSpeaker({ actor: this.actor });
     const rollMode = game.settings.get("core", "rollMode");
-    let label = `ability: ${
-      CONFIG.MARVEL_MULTIVERSE.damageAbility[this.system.ability]
-    }<br/>${this.type}: ${this.name}`;
-    label = this.system.damageType
-      ? `${label}<br/>damagetype: ${this.system.damageType}`
-      : label;
-    label =
-      this.system.isElemental && this.system.element
-        ? `${label}<br/>element: ${this.system.element}`
-        : label;
-
-    console.log(
-      `damageType: ${this.system.damageType} item.roll() : label: ${label}`
-    );
+    const abilityName = CONFIG.MARVEL_MULTIVERSE.damageAbility[this.system.ability];
+    const tokenImg = this.actor?.prototypeToken?.texture?.src || this.actor?.img;
+    const elementKey = this.system.isElemental ? this.system.element : null;
+    const label = buildRollFlavor({
+      tokenImg,
+      actorName: this.actor?.name,
+      powerName: this.name,
+      ability: abilityName ?? this.system.ability,
+      damageType: this.system.damageType,
+      element: elementKey,
+    });
 
     ChatMessage.create({
       speaker: speaker,
       rollMode: rollMode,
       flavor: label,
-      content: `<div>${this.system.description}</div><div>${
-        this.system.effect ? this.system.effect : ""
-      }</div>`,
+      content: `<div style="padding:4px 8px;" class="mm-chat-description">${this.system.description}</div>${
+        this.system.effect ? `<div style="padding:0 8px;" class="mm-chat-effect">${this.system.effect}</div>` : ""
+      }`,
     });
 
     if (this.system.formula && this.system.ability) {
@@ -79,16 +78,12 @@ export class MarvelMultiverseItem extends Item {
         rollData.formula,
         rollData.actor
       );
-      // If you need to store the value first, uncomment the next line.
-      // const result = await roll.evaluate();
-      const modLabel = `${label}, [ability] ${this.system.ability}`;
-
       roll.toMessage(
         {
           title: this.name,
           speaker: speaker,
           rollMode: rollMode,
-          flavor: modLabel,
+          flavor: label,
         },
         { rollMode: rollMode, itemId: this._id }
       );

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -53,6 +53,10 @@ export class MarvelMultiverseItem extends Item {
     label = this.system.damageType
       ? `${label}<br/>damagetype: ${this.system.damageType}`
       : label;
+    label =
+      this.system.isElemental && this.system.element
+        ? `${label}<br/>element: ${this.system.element}`
+        : label;
 
     console.log(
       `damageType: ${this.system.damageType} item.roll() : label: ${label}`

--- a/module/helpers/roll-flavor.mjs
+++ b/module/helpers/roll-flavor.mjs
@@ -1,0 +1,21 @@
+function _toTitleCase(str) {
+  if (!str) return "";
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+}
+
+export function buildRollFlavor({ tokenImg, actorName, powerName, ability, damageType, element }) {
+  let detailHtml = "";
+  if (powerName) detailHtml += `<div><b>Power:</b> ${powerName}</div>`;
+  const cols = [];
+  if (ability) cols.push(`<b>Ability:</b> ${_toTitleCase(ability)}`);
+  if (damageType) cols.push(`<b>Type:</b> ${_toTitleCase(damageType)}`);
+  if (element) cols.push(`<b>Element:</b> ${_toTitleCase(element)}`);
+  if (cols.length >= 3) {
+    detailHtml += `<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:4px;">${cols.map(c => `<span>${c}</span>`).join("")}</div>`;
+  } else {
+    detailHtml += cols.map(c => `<div>${c}</div>`).join("");
+  }
+  const tags = `<span style="display:none;">ability: ${ability || ""}${damageType ? " damagetype: " + damageType : ""}${element ? " element: " + element : ""}</span>`;
+  const tokenData = tokenImg ? ` data-token-img="${tokenImg}"` : "";
+  return `<div class="mm-roll-flavor"${tokenData}><div style="padding:4px 0;font-size:12px;">${detailHtml}</div>${tags}</div>`;
+}

--- a/module/sheets/character-sheet.mjs
+++ b/module/sheets/character-sheet.mjs
@@ -2,6 +2,7 @@ import {
   onManageActiveEffect,
   prepareActiveEffectCategories,
 } from "../helpers/effects.mjs";
+import { buildRollFlavor } from "../helpers/roll-flavor.mjs";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -391,12 +392,17 @@ export class MarvelMultiverseCharacterSheet extends ActorSheet {
     if (dataset.formula) {
       const ability =
         CONFIG.MARVEL_MULTIVERSE.damageAbility[dataset.label] ?? dataset.label;
-      let label = `ability: ${ability}<br/>${item?.type}: ${item?.name}`;
       const title = dataset.power ? `[power] ${dataset.power}` : "";
-
-      label = dataset.damagetype
-        ? `${label}<br/>damagetype: ${dataset.damagetype}`
-        : label;
+      const tokenImg = this.actor.prototypeToken?.texture?.src || this.actor.img;
+      const elementKey = item?.system?.isElemental ? item?.system?.element : null;
+      const label = buildRollFlavor({
+        tokenImg,
+        actorName: this.actor.name,
+        powerName: item?.name,
+        ability: ability,
+        damageType: dataset.damagetype,
+        element: elementKey,
+      });
 
       const speaker = ChatMessage.getSpeaker({ actor: this.actor });
       const rollMode = game.settings.get("core", "rollMode");

--- a/module/sheets/npc-sheet.mjs
+++ b/module/sheets/npc-sheet.mjs
@@ -2,6 +2,7 @@ import {
   onManageActiveEffect,
   prepareActiveEffectCategories,
 } from "../helpers/effects.mjs";
+import { buildRollFlavor } from "../helpers/roll-flavor.mjs";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -395,13 +396,21 @@ export class MarvelMultiverseNPCSheet extends ActorSheet {
 
     // Handle rolls that supply the formula directly.
     if (dataset.formula) {
+      const npcItemId = element.closest(".item")?.dataset?.itemId;
+      const npcItem = npcItemId ? this.actor.items.get(npcItemId) : null;
       const ability =
         CONFIG.MARVEL_MULTIVERSE.damageAbility[dataset.label] ?? dataset.label;
-      let label = `[ability] ${ability}`;
       const title = dataset.power ? `[power] ${dataset.power}` : "";
-      label = dataset.damageType
-        ? `${label} [damageType] ${dataset.damageType}`
-        : label;
+      const tokenImg = this.actor.prototypeToken?.texture?.src || this.actor.img;
+      const npcElementKey = npcItem?.system?.isElemental ? npcItem?.system?.element : null;
+      const label = buildRollFlavor({
+        tokenImg,
+        actorName: this.actor.name,
+        powerName: npcItem?.name,
+        ability: ability,
+        damageType: dataset.damageType,
+        element: npcElementKey,
+      });
 
       const roll = new CONFIG.Dice.MarvelMultiverseRoll(
         dataset.formula,


### PR DESCRIPTION
## Summary
- Add `statusId` to elemental config entries, mapping each element to a Foundry status effect
- Register elemental status effects with Foundry on init so `toggleStatusEffect()` resolves them
- On fantastic damage with an elemental power, display the elemental effect text and apply the corresponding status effect to targeted tokens
- Redesign power roll chat cards with styled red header, token image, and `buildRollFlavor` helper for consistent label formatting across CharacterSheet, NPCSheet, and item.roll() paths
- Update regex patterns in chat-message handler for robust ability/element/damageType parsing

## Test plan
- [ ] Roll an elemental power (e.g., fire, ice) from a character sheet and verify the chat card shows the element label
- [ ] Roll an elemental power from an NPC sheet and verify element appears in the chat card
- [ ] Get a fantastic success on an elemental power roll, click the damage button, and verify the elemental effect text appears and the status effect is applied to targeted tokens
- [ ] Verify non-elemental power rolls still work correctly without element labels
- [ ] Verify the styled chat card header appears with the actor's token image

<img width="430" height="479" alt="image" src="https://github.com/user-attachments/assets/282e6d21-af87-45b2-8d51-a59eb0fad8fd" />
